### PR TITLE
Update list of fields that don't affect VNC Server config

### DIFF
--- a/tasks/realVNCServerTask.go
+++ b/tasks/realVNCServerTask.go
@@ -25,7 +25,7 @@ const (
 
 var (
 	// these fields don't change the realvnc server config. they are only used by the task.
-	RvstNoChangeFields = []string{"ConfigFile", "ServerMode", "ReloadExecPath", "ExecCmd", "SkipReload"}
+	RvstNoChangeFields = []string{"ConfigFile", "ServerMode", "ReloadExecPath", "SkipReload", "UseVNCLicenseReload", "Backup", "SkipBackup"}
 )
 
 type RealVNCServerTask struct {


### PR DESCRIPTION
Some fields that are only used for script execution are being written to VNC Server configuration. This PR ensures these fields are excluded using the existing RvstNoChangeFields array.